### PR TITLE
Hide images before dom-ready.

### DIFF
--- a/main.js
+++ b/main.js
@@ -194,7 +194,7 @@ function createWindow() {
 
   mainWindow.hideWindow = () => {
     if (getSettings().hideOnMouseOut) {
-      mainWindow.hide();
+      hideWindow();
     }
   };
 

--- a/src/components/Browser.jsx
+++ b/src/components/Browser.jsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { remote } from 'electron'; // eslint-disable-line import/no-extraneous-dependencies
 import { tldExists } from 'tldjs';
-import transparentCSS from './css/webview/transparent.css';
 
 const win = remote.getCurrentWindow();
 
@@ -26,7 +25,6 @@ class Browser extends React.Component {
     this.handleLoadCommit = this.handleLoadCommit.bind(this);
     this.handleReload = this.handleReload.bind(this);
     this.handleStopReloadAnimation = this.handleStopReloadAnimation.bind(this);
-    this.handleDomReady = this.handleDomReady.bind(this);
     this.handleWillNavigate = this.handleWillNavigate.bind(this);
     this.handleEvents = this.handleEvents.bind(this);
     this.handleNavigateInPage = this.handleNavigateInPage.bind(this);
@@ -49,7 +47,6 @@ class Browser extends React.Component {
       { name: 'did-stop-loading', handler: this.handleLoadStop },
       { name: 'did-get-redirect-request', handler: this.handleLoadRedirect },
       { name: 'did-finish-load', handler: this.handleLoadCommit },
-      { name: 'dom-ready', handler: this.handleDomReady },
     ];
 
     const action = add ? 'addEventListener' : 'removeEventListener';
@@ -71,10 +68,6 @@ class Browser extends React.Component {
     if (e.isMainFrame) {
       this.setState({ location: e.url });
     }
-  }
-
-  handleDomReady() {
-    this.webview.insertCSS(transparentCSS);
   }
 
   // We don't remove the loading class immediately, instead we let the animation
@@ -187,6 +180,7 @@ class Browser extends React.Component {
           ref={(r) => { this.webview = r; }}
           src="https://www.google.com/"
           className="webview"
+          preload="./dist/preload.js"
         />
       </div>
     );

--- a/src/components/css/webview/transparent.css
+++ b/src/components/css/webview/transparent.css
@@ -1,7 +1,15 @@
-img {
+img, iframe {
   opacity: .1 !important;
 }
 
-img:hover {
+img:hover, iframe:hover {
   opacity: 1 !important;
+}
+
+div {
+  background-image: none !important;
+}
+
+div:hover {
+  background-image: inherit !important;
 }

--- a/src/preload.js
+++ b/src/preload.js
@@ -3,7 +3,7 @@ import transparentCSS from './components/css/webview/transparent.css';
 function addStyleString(str) {
   const node = document.createElement('style');
   node.innerHTML = str;
-  document.body.appendChild(node);
+  document.head.appendChild(node);
 }
 
 function addStyles() {

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,0 +1,17 @@
+import transparentCSS from './components/css/webview/transparent.css';
+
+function addStyleString(str) {
+  const node = document.createElement('style');
+  node.innerHTML = str;
+  document.body.appendChild(node);
+}
+
+function addStyles() {
+  if (document.body) {
+    addStyleString(transparentCSS);
+  } else {
+    setTimeout(addStyles, 10);
+  }
+}
+
+addStyles();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   entry: {
     browser: './src/components/Browser.jsx',
     settings: './src/components/Settings.jsx',
+    preload: './src/preload.js',
   },
   output: {
     path: path.resolve('dist'),


### PR DESCRIPTION
Currently CSS is injected using injectCSS after dom-ready, so there is a flash of images. This is problematic. This preloads the script and the script injects the CSS.  